### PR TITLE
Add missing consolekit and sdjson test requirements

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,6 @@
 # git+https://github.com/repo-helper/pyproject-examples
 coincidence>=0.2.0
+consolekit>=1.13.0
 coverage>=5.1
 coverage-pyver-pragma>=0.2.1
 importlib-metadata>=3.6.0
@@ -9,3 +10,4 @@ pytest>=6.0.0
 pytest-cov>=2.8.1
 pytest-randomly>=3.7.0
 pytest-timeout>=1.4.2
+sdjson>=0.5.0


### PR DESCRIPTION
Fixes #51.

This adds the test-only dependencies that are imported during the test run:

- consolekit, used by the consolekit.testing pytest plugin in 	ests/conftest.py
- sdjson, required by CLI/info tests after the pytest plugin loads

These packages are added to 	ests/requirements.txt so contributors installing the documented test requirements get a complete environment.